### PR TITLE
fix `threshold_setting` typo

### DIFF
--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -77,7 +77,7 @@ function defaults ( ) {
     , tddAdjBasal: false // Enable adjustment of basal based on the ratio of 24 h : 10 day average TDD
     , enableSMB_high_bg: false // enable SMBs when a high BG is detected, based on the high BG target (adjusted or profile)
     , enableSMB_high_bg_target: 110 // set the value enableSMB_high_bg will compare against to enable SMB. If BG > than this value, SMBs should enable.
-    , threshold_setting: 0.60 // Use a configurable threshold setting
+    , threshold_setting: 60 // Use a configurable threshold setting
   }
 }
 


### PR DESCRIPTION
This just fixes a typo imported from [Artificial-Pancras/oref2](https://github.com/Artificial-Pancreas/oref2/commit/dbe86f63ed1c3f4a78b4c2af8d831918f2fd9b36). Since `threshold_setting` already has a minimum used value of 60 in [determine-basal.js](https://github.com/nightscout/trio-oref/blob/b45483738b5f978399f3e91b96eab6c457a614d3/lib/determine-basal/determine-basal.js#L1024), having it defaulted to anything lower than 60 shouldn't have affected anything anyway.

I will replace this line with a link to the PR in nightscout/Trio once that is created.